### PR TITLE
File protocol errors are now propagated correctly

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -17,10 +17,10 @@ func toHTTPError(err error) (msg string, code int) {
 		return herr.Body(), herr.StatusCode()
 	}
 	if errors.Is(err, fs.ErrNotExist) {
-		return "404 page not found", http.StatusNotFound
+		return "404 page not found: " + err.Error(), http.StatusNotFound
 	}
 	if errors.Is(err, fs.ErrPermission) {
-		return "403 Forbidden", http.StatusForbidden
+		return "403 Forbidden: " + err.Error(), http.StatusForbidden
 	}
 	// Default:
 	return "500 Internal Server Error: " + err.Error(), http.StatusInternalServerError

--- a/core/server.go
+++ b/core/server.go
@@ -204,7 +204,7 @@ func (s *Server) serveProtocols(res http.ResponseWriter, req *http.Request) erro
 	upath, appliedAlias := s.aliases.apply(upath)
 	u, err := url.Parse(upath)
 	if err != nil {
-		return fmt.Errorf("failed to parse %q as URL: %s", upath, err)
+		return fmt.Errorf("failed to parse %q as URL: %w", upath, err)
 	}
 	u.RawQuery = req.URL.RawQuery
 	p := protocol.Find(u.Scheme)
@@ -213,7 +213,7 @@ func (s *Server) serveProtocols(res http.ResponseWriter, req *http.Request) erro
 	}
 	rsrc, err := s.open(p, u, req)
 	if err != nil {
-		return fmt.Errorf("failed to open %s; %s", upath, err)
+		return fmt.Errorf("failed to open %s; %w", upath, err)
 	}
 	if rsrc == nil {
 		return fmt.Errorf("nil resource for %s", upath)
@@ -233,7 +233,7 @@ func (s *Server) serveProtocols(res http.ResponseWriter, req *http.Request) erro
 	qp, err := qparamsParse(req.URL.RawQuery)
 	if err != nil {
 		rsrc.Close()
-		return fmt.Errorf("failed to parse query string: %s", err)
+		return fmt.Errorf("failed to parse query string: %w", err)
 	}
 	if parsed, ok := rsrc.Strings(protocol.ParsedKeys); ok {
 		qp = qp.deleteKeys(parsed)
@@ -254,7 +254,7 @@ func (s *Server) serveProtocols(res http.ResponseWriter, req *http.Request) erro
 			if r != nil {
 				r.Close()
 			}
-			return fmt.Errorf("default filters for %q causes problem: %s", upath, err)
+			return fmt.Errorf("default filters for %q causes problem: %w", upath, err)
 		}
 	}
 	defer r.Close()

--- a/protocol/file/file.go
+++ b/protocol/file/file.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/url"
 	"os"
@@ -71,7 +72,8 @@ func (f *File) Open(u *url.URL) (*resource.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(m) == 1 {
+	switch len(m) {
+	case 0, 1:
 		return f.openOne(name)
 	}
 	return f.openMulti(m, name)
@@ -80,7 +82,7 @@ func (f *File) Open(u *url.URL) (*resource.Resource, error) {
 func (f *File) openOne(name string) (*resource.Resource, error) {
 	// TODO: consider relative path.
 	if !fc.isAccessible(name) {
-		return nil, fmt.Errorf("forbidden: %s", name)
+		return nil, fs.ErrPermission
 	}
 	fi, err := os.Lstat(name)
 	if err != nil {


### PR DESCRIPTION
* Change format of error messages
* Wrapped to allow error propagation
* Invalid glob strings now throw an error

Fixed https://github.com/koron/nvgd/issues/102