### PR TITLE
Limit with new lines 

### DIFF
--- a/protocol/db/handler.go
+++ b/protocol/db/handler.go
@@ -141,7 +141,7 @@ func hasSelect(q string) bool {
 }
 
 var rxSelectCount = regexp.MustCompile(`(?imsU:\bSELECT\b.*\bCOUNT\b.*\(.*\bFROM\b)`)
-var rxHasLimit = regexp.MustCompile(`(?imsU:\bLIMIT\b[ ].*\d+)`)
+var rxHasLimit = regexp.MustCompile(`(?imsU:\bLIMIT\b\s.*\d+)`)
 
 // hasLimit checks a query has LIMIT clause or not.
 func hasLimit(q string) bool {

--- a/protocol/db/handler_test.go
+++ b/protocol/db/handler_test.go
@@ -45,10 +45,15 @@ func TestHasLimit(t *testing.T) {
 		{`SELECT * FROM user LIMIT 10000`, true}, // LIMIT with number
 		{`LIMIT 10000`, true},                    // only LIMIT with number
 		{`SELECT * FROM user LIMIT abc`, false},  // LIMIT without number
+		{"LIMIT\n10000", true},                   // LIMIT with a new line
+		{"LIMIT \n10000", true},                  // LIMIT with a new line
+		{"LIMIT\n 10000", true},                  // LIMIT with a new line
+		{"LIMIT\n\n10000", true},                 // LIMIT with new lines
+		{"LIMIT\n\n\n10000", true},               // LIMIT with new lines
 	} {
 		got := hasLimit(tc.query)
 		if got != tc.want {
-			t.Errorf("unexpected hasLimit return: want=%t got=%t:#%d: %s", tc.want, got, i, tc.query)
+			t.Errorf("unexpected hasLimit return: want=%t got=%t:#%d: %q", tc.want, got, i, tc.query)
 		}
 	}
 }


### PR DESCRIPTION
This fixes #106

The "LIMIT" was followed by only a space as a delimiter. This has been changed to allow other spaces, including newlines.