### PR TITLE
Add documentation for OPFS protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Nvgd supports these `protocol`s:
     [See docuemnt for detail](doc/protocol-duckdb.md).
 
 * `opfs` - Operate with OPFS (Origin Private File System)
+
     [See document for detail](doc/protocol-opfs.md).
 
 * `examples` - Example files to use demo/document of filters

--- a/doc/protocol-opfs.md
+++ b/doc/protocol-opfs.md
@@ -15,7 +15,7 @@ This document describes the user interface (UI) provided by NVGD for interacting
 
 ## Accessing the OPFS Interface
 
-The NVGD OPFS interface is typically available at the `/opfs/` URL path of your NVGD instance. For example, if your NVGD instance is running at `http://localhost:9280`, you would access the OPFS interface by navigating your browser to `http://localhost:9280/opfs/`.
+The NVGD OPFS interface is available at the `/opfs/` URL path of your NVGD instance. For example, if your NVGD instance is running at `http://localhost:9280`, you would access the OPFS interface by navigating your browser to `http://localhost:9280/opfs/`.
 
 ## OPFS User Interface and Functionalities
 
@@ -32,21 +32,22 @@ The UI allows users to navigate the OPFS directory structure.
     *   A "Create Directory" button or input field allows users to create new subdirectories within the current directory.
 *   **Moving Up and Down the Directory Tree:**
     *   Clicking on a directory name in the list navigates into that directory.
-    *   A "Parent Directory" button (often represented as ".." or an up arrow icon) allows navigation to the directory containing the current one.
-    *   A breadcrumb trail might also be present, showing the current path and allowing quick navigation to any parent directory in the path.
+    *   A breadcrumb trail also be present, showing the current path and allowing quick navigation to any parent directory in the path.
 
 ### 2. File Operations
 
 Various operations can be performed on individual files and directories.
 
-*   **Uploading Local Files:**
-    *   An "Upload File(s)" button opens a system file dialog, allowing users to select one or more files from their local computer to be uploaded into the current OPFS directory.
-*   **Creating or Editing Files Directly:**
-    *   A "Create New File" button might allow users to create a blank text file or a file of a specific type.
-    *   An "Edit File" option (often available when selecting a file, especially text-based files) would open a simple in-browser text editor to modify the file's content. Changes are saved back to OPFS.
+
+*   **Uploading a Local File:**
+    *   In the Upload a local file section, you can select a file in the file picker, change the name of the file to upload if necessary, and then click the Upload button to upload the local file to the current directory in OPFS.
+*   **Editor:**
+    *   You can create new files or update existing files.
+    *   Specify a file name, enter file contents, and press the "Create or update a file" button to create or update a file with that file name and contents.
+    *   If the file is less than 64KiB, clicking the "Editor" action in the list will load the file's name and contents into the Editor input fields, making it easier to update existing files.
 *   **Removing Files/Directories:**
-    *   A "Remove" or "Delete" option (often an icon or a button available next to each file/directory, or after selecting items) allows users to delete selected files or directories.
-    *   A confirmation prompt is typically shown before permanent deletion. Deleting a directory will also delete all its contents.
+    *   A "Remove" action allows users to delete a file or directory.
+    *   A confirmation prompt is shown before permanent deletion. Deleting a directory will also delete all its contents.
 *   **Saving Files from OPFS to Local Disk (Download):**
     *   A "Download" option (often an icon or a button available next to each file, or after selecting a file) allows users to save a copy of the selected file from OPFS to their computer's local file system.
 
@@ -54,15 +55,14 @@ Various operations can be performed on individual files and directories.
 
 The UI supports operations on multiple selected items.
 
-*   **Selection:** Users can typically select multiple files and/or directories using checkboxes next to each item or by using standard keyboard shortcuts (e.g., Ctrl+Click, Shift+Click).
-*   **"Open multiple files with DuckDB":**
-    *   When multiple files (e.g., Parquet, CSV) are selected, an action button like "Open selected with DuckDB" or "Load into DuckDB" becomes available.
-    *   Clicking this button will typically instruct the integrated DuckDB WASM instance to create views or tables based on the selected files, allowing users to query them collectively. The exact mechanism might involve creating separate views for each file or attempting to union compatible files.
-*   **Other Batch Actions:** Depending on the implementation, other batch actions like "Download Selected" or "Delete Selected" might be available.
+*   **Selection:** Users can select multiple files and/or directories using checkboxes next to each item.
+*   **"Open selected files with DuckDB":**
+    *   When multiple files (e.g., Parquet, CSV) are selected, an action button like "Open selected files with DuckDB" becomes available.
+    *   Clicking this button will instruct the integrated DuckDB WASM instance to create views based on the selected files, allowing users to query them collectively. The exact mechanism might involve creating separate views for each file or attempting to union compatible files.
 
 ### 4. "Delete all contents" Button
 
-*   **Functionality:** A prominent button, often labeled "Delete all contents in this directory," "Empty Directory," or similar, is provided.
+*   **Functionality:** A prominent button, often labeled "Delete all contents in this directory" is provided.
 *   **Purpose:** This allows for the quick removal of all files and subdirectories within the currently viewed OPFS directory.
 *   **Confirmation:** Due to its destructive nature, clicking this button will always trigger a confirmation dialog asking the user to verify they indeed want to delete all content in the current directory. This helps prevent accidental data loss.
 
@@ -83,11 +83,12 @@ The DuckDB integration primarily supports the following file types for direct qu
 
 ### Opening Single Files with DuckDB
 
-When you choose to open a single supported file from the OPFS interface with DuckDB (e.g., via a context menu option "Open with DuckDB" or a dedicated button):
+When you choose to open a single supported file from the OPFS interface with DuckDB (e.g., via an action "DuckDB"):
 
 *   NVGD will instruct the in-browser DuckDB instance to create a view for that file.
 *   This view is typically named `opfs`.
 *   You can then query this view directly in the DuckDB SQL shell. For example, if you opened `my_data.csv`:
+
     ```sql
     SELECT * FROM opfs;
     SELECT column_name, COUNT(*) FROM opfs GROUP BY column_name;
@@ -99,8 +100,9 @@ The interface also allows you to select and open multiple supported files with D
 
 *   When multiple files are selected and opened with DuckDB:
     *   NVGD will instruct DuckDB to create a separate view for each selected file.
-    *   These views are typically named sequentially, such as `opfs0`, `opfs1`, `opfs2`, and so on. The numbering corresponds to the order in which the files were selected or processed.
+    *   These views are named sequentially, such as `opfs0`, `opfs1`, `opfs2`, and so on. The numbering corresponds to the order in which the files were selected or processed.
 *   You can then query these individual views or join them in your SQL queries. For example, if you opened `data_part1.parquet` and `data_part2.parquet`:
+
     ```sql
     -- Query the first file
     SELECT * FROM opfs0;
@@ -113,4 +115,5 @@ The interface also allows you to select and open multiple supported files with D
     FROM opfs0 AS a
     JOIN opfs1 AS b ON a.id = b.id;
     ```
+
 This integration allows for flexible data analysis by bringing the power of DuckDB directly to the files you manage within OPFS.

--- a/protocol/opfs/assets/index.html
+++ b/protocol/opfs/assets/index.html
@@ -134,18 +134,18 @@ a {
       <textarea id="touch-body" style="margin-top: 0.2em; width: 100%; max-width: 100%; min-width: 100%; min-height: 10em;"></textarea><br>
     </div>
     <div>
-      <b>Upload local files</b><br>
+      <b>Upload a local file</b><br>
       <input type="file" id="upload-file" onchange="uiUploadChange()"></file>
       Upload as: <input id="upload-name"></input>
       <button onclick="uiUpload()">Upload</button>
     </div>
     <div>
       <b>Acitons for multiple files</b><br>
-      <button id="multiple-duckdb" disabled="true" onclick="uiDuckDBMultiple()">Open multiple files with DuckDB</button><br>
+      <button id="multiple-duckdb" disabled="true" onclick="uiDuckDBMultiple()">Open selected files with DuckDB</button><br>
     </div>
     <div>
       <b>Delete all contents</b><br>
-      <button onclick="uiClearAll()">Delete all contents from the current direcotry</button>
+      <button onclick="uiClearAll()">Delete all contents in this direcotry</button>
     </div>
   </section>
 


### PR DESCRIPTION
This commit introduces documentation for the OPFS (Origin Private File System) protocol.

The new documentation file, `doc/protocol-opfs.md`, covers:
- An introduction to OPFS and its purpose within the project.
- A description of the user interface elements and their functionalities, including directory navigation, file operations (upload, create, edit, remove, save to local), and actions for multiple files.
- How to access the OPFS interface (typically via the `/opfs/` path).
- Details of the DuckDB integration, including supported file types (CSV, XLSX, JSON, Parquet) and how single and multiple files are represented as views in DuckDB.

A link to this new documentation has also been added to the main `README.md` under the "Protocols" section.